### PR TITLE
refactor: don't mix o(SP) and n-o(SP) syntax

### DIFF
--- a/asm_amd64.s
+++ b/asm_amd64.s
@@ -11,6 +11,9 @@
 
 // func DebugWrite(fd uintptr, p unsafe.Pointer, n int32) int32
 TEXT ·DebugWrite(SB),NOSPLIT,$40-20
+        // Stack layout:
+        // arg-0x28(SP) *Closure     // 0x08 bytes
+        // closure-0x20(SP) Closure  // 0x20 bytes
 #define TEMP_closure(offset) closure-(0x20-offset)(SP)
         MOVQ $·debugWriteOnSystemStackTrampoline(SB), AX
         MOVQ AX, TEMP_closure(0x00)  // closure.f
@@ -22,7 +25,7 @@ TEXT ·DebugWrite(SB),NOSPLIT,$40-20
         MOVL AX, TEMP_closure(0x18)  // closure.n
 
         MOVQ $TEMP_closure(0), AX
-        MOVQ AX, 0(SP)               // f = &closure
+        MOVQ AX, arg-0x28(SP)        // f = &closure
 	CALL runtime·systemstack(SB)
 
         MOVQ TEMP_closure(0x1c), AX  // closure.result
@@ -40,11 +43,11 @@ TEXT ·debugWriteOnSystemStackTrampoline(SB),NOSPLIT,$32-0
         MOVQ DX, closure-0(SP)
 
         MOVQ 0x08(DX), AX                  // closure.fd
-        MOVQ AX, 0(SP)
+        MOVQ AX, arg_fd-32(SP)
         MOVQ 0x10(DX), AX                  // closure.p
-        MOVQ AX, 8(SP)
+        MOVQ AX, arg_p-24(SP)
         MOVL 0x18(DX), AX                  // closure.n
-        MOVL AX, 16(SP)
+        MOVL AX, arg_n-16(SP)
         CALL ·debugWriteOnSystemStack(SB)  // Clobbers DX.
         MOVQ closure-0(SP), DX
         MOVL AX, 0x1c(DX)                  // closure.bytesWritten

--- a/asm_arm64.s
+++ b/asm_arm64.s
@@ -11,6 +11,9 @@
 
 // func DebugWrite(fd uintptr, p unsafe.Pointer, n int32) int32
 TEXT ·DebugWrite(SB),NOSPLIT,$40-20
+        // Stack layout:
+        // arg-0x28(SP) *Closure     // 0x08 bytes
+        // closure-0x20(SP) Closure  // 0x20 bytes
 #define TEMP_closure(offset) closure-(0x20-offset)(SP)
         MOVD $·debugWriteOnSystemStackTrampoline(SB), R0
         MOVD R0, TEMP_closure(0x00)  // closure.f
@@ -22,7 +25,7 @@ TEXT ·DebugWrite(SB),NOSPLIT,$40-20
         MOVW R0, TEMP_closure(0x18)  // closure.n
 
         MOVD $TEMP_closure(0), R0
-        MOVD R0, 8(RSP)              // f = &closure
+        MOVD R0, arg-0x28(SP)        // f = &closure
 	CALL runtime·systemstack(SB)
 
         MOVW TEMP_closure(0x1c), R0  // closure.result
@@ -40,11 +43,11 @@ TEXT ·debugWriteOnSystemStackTrampoline(SB),NOSPLIT,$32-0
         MOVD R26, closure-0(SP)
 
         MOVD 0x08(R26), R0                 // closure.fd
-        MOVD R0, 8(RSP)
+        MOVD R0, arg_fd-32(SP)
         MOVD 0x10(R26), R0                 // closure.p
-        MOVD R0, 16(RSP)
+        MOVD R0, arg_p-24(SP)
         MOVW 0x18(R26), R0                 // closure.n
-        MOVW R0, 24(RSP)
+        MOVW R0, arg_n-16(SP)
         CALL ·debugWriteOnSystemStack(SB)  // Clobbers R26.
         MOVD closure-0(SP), R26
         MOVD R0, 0x1c(R26)                 // closure.bytesWritten


### PR DESCRIPTION
0(SP) and n-0(SP) look similar, but they have different semantics. From <https://go.dev/doc/asm>:

> On architectures with a hardware register named SP, the name prefix
> distinguishes references to the virtual stack pointer from references to the
> architectural SP register. That is, `x-8(SP)` and `-8(SP)` are different
> memory locations: the first refers to the virtual stack pointer
> pseudo-register, while the second refers to the hardware's SP register.

I think mixing the two syntaxes within the same function is confusing. Refactor our code to use one syntax or the other, not a mix. This has the extra benefit of making the amd64 and arm64 implementations of
debugWriteOnSystemStackTrampoline more similar to each other.

## Test plan

   $ $env:GOARCH = 'amd64'
   $ go test
   $ $env:GOARCH = 'arm64'
   $ go test